### PR TITLE
Fix typo s/mutliple/multiple/

### DIFF
--- a/src/s3fs.cpp
+++ b/src/s3fs.cpp
@@ -3896,7 +3896,7 @@ static int parse_passwd_file(bucketkvmap_t& resmap)
       secret    = trim(iter->substr(first_pos + 1, string::npos));
     }
     if(resmap.end() != resmap.find(bucket)){
-      S3FS_PRN_EXIT("there are mutliple entries for the same bucket(%s) in the passwd file.", ("" == bucket ? "default" : bucket.c_str()));
+      S3FS_PRN_EXIT("there are multiple entries for the same bucket(%s) in the passwd file.", ("" == bucket ? "default" : bucket.c_str()));
       return -1;
     }
     kv.clear();


### PR DESCRIPTION
This typo was found during package review. Nothing to add really.